### PR TITLE
Copy package-lock.json into container

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /usr/src/app
 # host machine) and will take preference being in the project directory.
 ONBUILD WORKDIR /usr/src
 ONBUILD COPY package.json /usr/src/
+ONBUILD COPY package-lock.json /usr/src/
 ONBUILD RUN npm install
 ONBUILD COPY . /usr/src/app
 


### PR DESCRIPTION
This will make it so that we can depend on consistency across developers and on CI